### PR TITLE
Resolve `UData` offsets in `eval_addr`.

### DIFF
--- a/async-backtrace/src/lib.rs
+++ b/async-backtrace/src/lib.rs
@@ -175,6 +175,8 @@ fn crawl_type<R: gimli::Reader<Offset = usize> + PartialEq>(
                         }] => return Ok(Some(address)),
                         _ => eprintln!("Warning: Unsupported evaluation result {:?}", result,),
                     }
+                } else if let AttributeValue::Udata(offset) = attr {
+                    return Ok(Some(start + offset))
                 }
             }
             Ok(None)


### PR DESCRIPTION
(Please feel free to totally ignore this while you're on vacation!)

For me (using `rustc 1.67.0-nightly (edf018221 2022-11-02)`), this change was necessary to get `async-backtrace` to actually recurse in to the DWARF info and produce async backtraces. 